### PR TITLE
fix: mock react-refresh in dev server to fix runtime error

### DIFF
--- a/packages/core/src/vite/plugin/transform/hooks/transform/stages/3.evaluate-module/serve/index.ts
+++ b/packages/core/src/vite/plugin/transform/hooks/transform/stages/3.evaluate-module/serve/index.ts
@@ -3,6 +3,7 @@ import type { ViteDevServer } from "vite";
 import { loadModule } from "../loadModule";
 import { loadBuiltinModule } from "../loaders/loadBuiltinModule";
 import { loadNodeModule } from "../loaders/loadNodeModule";
+import { loadReactRefreshModule } from "./loaders/loadReactRefresh";
 import { loadRelativeModule } from "./loaders/loadRelativeModule";
 import { loadViteModule } from "./loaders/loadViteModule";
 import { normalizeSpecifier } from "./normalizeSpecifier";
@@ -35,7 +36,13 @@ export function createLinker({
     };
 
     const { error, module } = await loadModule(
-      [loadBuiltinModule, loadNodeModule, loadViteModule, loadRelativeModule],
+      [
+        loadBuiltinModule,
+        loadNodeModule,
+        loadReactRefreshModule,
+        loadViteModule,
+        loadRelativeModule,
+      ],
       loadModuleArgs,
     );
 

--- a/packages/core/src/vite/plugin/transform/hooks/transform/stages/3.evaluate-module/serve/loaders/loadReactRefresh.ts
+++ b/packages/core/src/vite/plugin/transform/hooks/transform/stages/3.evaluate-module/serve/loaders/loadReactRefresh.ts
@@ -1,0 +1,33 @@
+import vm, { type Module } from "node:vm";
+import type { ViteDevServer } from "vite";
+import type { LoadModuleReturn } from "../../types";
+
+export async function loadReactRefreshModule({
+  modulesCache,
+  specifier,
+  referencingModule,
+}: {
+  modulesCache: Map<string, Module>;
+  specifier: string;
+  referencingModule: Module;
+  server: ViteDevServer;
+  basePath: string;
+}): Promise<LoadModuleReturn> {
+  if (specifier !== "/@react-refresh") {
+    return { error: new Error("This is not /@react-refresh"), module: null };
+  }
+  const m = new vm.SyntheticModule(
+    ["default"],
+    () => {
+      m.setExport("default", {
+        injectIntoGlobalHook: (..._args: unknown[]) => {},
+      });
+    },
+    {
+      context: referencingModule.context,
+      identifier: `vm:module<react-refresh>(${specifier})`,
+    },
+  );
+  modulesCache.set(specifier, m);
+  return { error: null, module: m };
+}


### PR DESCRIPTION
Real HMR codes are useless in style evaluation. Now `/@react-refresh` does nothing in dev server.